### PR TITLE
[821876] Fix for microflow execute failure

### DIFF
--- a/src/CameraWidgetForPhoneGap/widget/CameraWidgetForPhoneGap.js
+++ b/src/CameraWidgetForPhoneGap/widget/CameraWidgetForPhoneGap.js
@@ -231,9 +231,11 @@ require([
         _executeMicroflow: function() {
             if (this.onchangemf && this._contextObj) {
                 window.mx.data.action({
-                    actionname: this.onchangemf,
-                    applyto: "selection",
-                    guids: [ this._contextObj.getGuid() ],
+                    params: {
+                        actionname: this.onchangemf,
+                        applyto: "selection",
+                        guids: [ this._contextObj.getGuid() ]
+                    },
                     callback: function(objs) {
                         //ok
                     },


### PR DESCRIPTION
As part of this bug, modler throws a `NullPointerException` because of `params` equal to null.
