### PR TITLE
Fix getCSRFToken & bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camera-widget-for-phonegap",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Enable native camera functionality within your Mendix hybrid app",
   "repository": {
     "type": "git",

--- a/src/CameraWidgetForPhoneGap/widget/CameraWidgetForPhoneGap.js
+++ b/src/CameraWidgetForPhoneGap/widget/CameraWidgetForPhoneGap.js
@@ -180,7 +180,7 @@ require([
 
                 var url = mx.appUrl +
                     "file?guid=" + this._contextObj.getGuid() +
-                    "&csrfToken=" + mx.session.getCSRFToken();
+                    "&csrfToken=" + mx.session.getConfig('csrftoken');
 
                 var ft = new FileTransfer();
                 ft.upload(this._imageUrl, url, refreshObject, error, options);

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-	<clientModule name="CameraWidgetForPhoneGap" version="3.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+	<clientModule name="CameraWidgetForPhoneGap" version="3.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
 		<widgetFiles>
 			<widgetFile path="CameraWidgetForPhoneGap/CameraWidgetForPhoneGap.xml"/>
 		</widgetFiles>


### PR DESCRIPTION
`mx.session.getCSRFToken` is broken in Mendix 7.6. This should be replaced with `mx.session.getConfig('csrftoken')`, which works in Mendix 5 to now.