### PR TITLE
Add blocking upload progress options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,10 @@ and run further actions.
 Setting that determines where the image will come from: gallery or the camera.
 
 ### Image quality
-Be aware that setting this higher will be more taxing and will take longer to upload.  If quality
-width and height are both set to `0`, the image will be saved full size.
+This will change the image-width and height on output. Be aware that setting this higher will be more taxing and will take longer to upload. If quality width and height are both set to `0`, the image will be saved full size.
 
 #### Quality width
-The width of the image that is eventually stored and send to the application, between 0 and 100. 
-#### Quality height
-The height of the image that is eventually stored and send to the application, between 0 and 100.
+Width in pixels to scale image. Must be used with targetHeight. Aspect ratio remains constant.
 
+#### Quality height
+Height in pixels to scale image. Must be used with targetWidth. Aspect ratio remains constant.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CameraWidgetForPhoneGap",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "description": "Enable native camera functionality within your Mendix hybrid app",
   "license": "Apache-2.0",
   "author": "Mendix BV",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CameraWidgetForPhoneGap",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "description": "Enable native camera functionality within your Mendix hybrid app",
   "license": "Apache-2.0",
   "author": "Mendix BV",

--- a/src/CameraWidgetForPhoneGap/CameraWidgetForPhoneGap.xml
+++ b/src/CameraWidgetForPhoneGap/CameraWidgetForPhoneGap.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <widget id="CameraWidgetForPhoneGap.widget.CameraWidgetForPhoneGap" needsEntityContext="true" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/">
     <name>Camera</name>
-    <description>Creates a button to use the phone camera option within a Mendix Developer application.</description>
+    <description>Creates a button to use the phone camera option within a Mendix Developer application</description>
     <icon>iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAA21BMVEUAAAD///+A//9VVVVmZmZVVVVgYGBVVVVmZmZVVVViYmJeXl5SuP9cXFxJtv9YWFhVVVVYWFhXV1dVVVVVVVVXV1dWVlZXV1dJs/lWVlZJs/lVVVVJsfdJsfhIsvhXV1dVVVVWVlZWVlZWVlZVVVVWVlZWVlZVVVVWVlZWVlZVVVVWVlZVVVVVVVVIsfhJsPhJsfhJsfhVVVVJsfdVVVVJsfhVVVVVVVVWVlZJsPdVVVVVVVVVVVVWVlZIsPhVVVVJsfhIsPhVVVVVVVVVVVVJsPhVVVVIsPdVVVUd0v+1AAAAR3RSTlMAAQIDBQYICQoMDRMZGRwgJDQ1NkhJSk9QUFdjZWlqcHJ5g4WZmpufoKOrrLCxtLW2vcLIyNHS1d/j5Ons7vDw8fP19vn8/PqNolUAAAJ4SURBVHgB7VdvX+IwDO6YoIhDBO4QYTL+HJwip4ITVByHotv3/0SX5IdzuWxs/vrW5w1tw/OsTZq0Vcn4hll1htPFcrNZLqa/nKr5NfZeY7wKGFaXjb3M9P3uMojBsrufbe6txyABj60MK/k53/77ddKpV0r5fKlS70xet4PzHyl0ox8QnkfNg+j4QXP0HBD6xi5+8SpAvPQOpe2w90LGq2Iy//ge//E+sOLN1uAd7ffHifwn8tSJSsQJ+fcpQaFI37+z1A5YdzSH2FUYtP6LgtqJwgX5Ic6TfeKrVJBCPyb+NP9CukCBViH2gzlH/1kqAyz05NxUHC2MH/f/6YO/xcMpjwVGs/Vf/qDqgA2dvfkh3s6YaYCz5ZnVxf1nCX6CgoV7ssvyH/O3J/iJCj3M7mh9aGL+4P7PnbseJ3Exz7VzmBeYWY2IwBj6I2zY4qNiOjaOjIBwGYkh1q8mtlzBFwrux5RXn5GsYf2g/P/ry9DxkPoe1QesMNXQ7EBvQi0fEEmP9my9nrUN6nD7BChOODyEXkcKHN36hNsjKdAByjAcnkKvLgQM4pMCzOH6mtnrQJmGAgvoVYRA2w/RBoE/zF4ByiIUwG1UEgIzaN+UyzfwMxNLKOFWCgU20MsLgTW0y0qV4WctBPJA2egL6C8huxMJ0onZw4iQYdTfSNpbmSeTEJBAO0smls5ZBXg684Li+amgdP7NC4pqfJQ0N13AjZY0UVTtdAGbFVVe1llRjYXnnudkWZcHi0TawSKPNgl5tOkfrvrHu/4FQ/+Ko3/J0r/m6V809a+6Wpdtjeu+xoND48mj8egapzy6BMza57Nv6NR2zP0b/wDScUGfAMfR4QAAAABJRU5ErkJggg==</icon>
     <phonegap enabled="true"/>
     <properties>
         <property key="buttonClass" type="string" defaultValue="wx-mxwx-button-extra">
             <caption>Class</caption>
             <category>Button</category>
-            <description>The class on the button.</description>
+            <description>The CSS class on the button</description>
         </property>
         <property key="buttonText" type="string" defaultValue="activate camera">
             <caption>Label</caption>
             <category>Button</category>
-            <description>The label on the button.</description>
+            <description/>
         </property>
         <property key="imageContainerClass" type="string" defaultValue="wx-mxwx-imagecontainer-extra">
             <caption>Image container class</caption>
             <category>Appearance</category>
-            <description>The class on the button.</description>
+            <description>The CSS class on the preview</description>
         </property>
         <property key="imageWidth" type="integer" defaultValue="150">
             <caption>Width</caption>
             <category>Appearance</category>
-            <description>The width of the image.</description>
+            <description>The width of the image thumbnail</description>
         </property>
         <property key="imageHeight" type="integer" defaultValue="150">
             <caption>Height</caption>
             <category>Appearance</category>
-            <description>The height of the image.</description>
+            <description>The height of the image thumbnail</description>
         </property>
         <property key="imageLocation" type="enumeration" defaultValue="right">
             <caption>Image location</caption>
             <category>Appearance</category>
-            <description>The position where the image is set.</description>
+            <description>The position where the thumbnail image is set</description>
             <enumerationValues>
                 <enumerationValue key="above">Above</enumerationValue>
                 <enumerationValue key="below">Below</enumerationValue>
@@ -44,33 +44,33 @@
         <property key="targetWidth" type="integer" defaultValue="150">
             <caption>Quality width</caption>
             <category>Image quality</category>
-            <description>The width of the image.</description>
+            <description>The width of the captured image</description>
         </property>
         <property key="targetHeight" type="integer" defaultValue="150">
             <caption>Quality height</caption>
             <category>Image quality</category>
-            <description>The height of the image.</description>
+            <description>The height of the captured image</description>
         </property>
         <property key="autoSaveEnabled" type="boolean" defaultValue="false">
             <caption>Autosave</caption>
-            <category>Behaviour</category>
+            <category>Behavior</category>
             <description>Enable autosave to automatically save your image</description>
         </property>
         <property key="onchangemf" type="microflow" required="false">
             <caption>On save microflow</caption>
-            <category>Behaviour</category>
-            <description>This microflow is called when the object is saved. use this to commit the object when using autosave</description> 
+            <category>Behavior</category>
+            <description>This microflow is called when the object is saved. Use this to commit the object when using autosave</description> 
             <returnType type="Void"/>
         </property>
         <property key="onSaveNanoflow" type="nanoflow" required="false">
             <caption>On save nanoflow</caption>
-            <category>Behaviour</category>
-            <description>This nanoflow is called when the object is saved. use this to commit the object when using autosave</description> 
+            <category>Behavior</category>
+            <description>This nanoflow is called when the object is saved. Use this to commit the object when using autosave</description> 
             <returnType type="Void"/>
         </property>
         <property key="pictureSource" type="enumeration" defaultValue="camera">
-            <caption>Picture Source</caption>
-            <category>Behaviour</category>
+            <caption>Picture source</caption>
+            <category>Behavior</category>
             <description>Grab image from either the camera or the phone's image gallery</description>
             <enumerationValues>
                 <enumerationValue key="camera">Camera</enumerationValue>
@@ -79,21 +79,21 @@
         </property>
         <property key="blockingUpload" type="enumeration" defaultValue="disabled">
             <caption>Block during upload</caption>
-            <category>Behaviour</category>
-            <description>Show progress message during upload (block UI) prevent form user interaction. Or 'On form save' upload can be started, only on save of the form show progress will be shown when the upload is not completed</description>
+            <category>Behavior</category>
+            <description>Prevent any form interaction. Shows the blocking progress message during the whole upload. Or show 'On form save', useful for 'autosave', will only show the blocking progress when the form will be closed, and the upload is not completed</description>
             <enumerationValues>
                 <enumerationValue key="disabled">None</enumerationValue>
                 <enumerationValue key="duringUpload">During upload</enumerationValue>
-                <enumerationValue key="onFormSave">On from save</enumerationValue>
+                <enumerationValue key="onFormSave">On form save</enumerationValue>
             </enumerationValues>
         </property>
         <property key="progressText" type="translatableString" required="false" >
             <caption>Progress upload text</caption>
-            <category>Behaviour</category>
+            <category>Behavior</category>
             <description/>
             <translations>
-                <translation lang="en_US">Uploading image in progress ...</translation>
-                <translation lang="nl_NL">Bezig met uploaden van de afbeelding ...</translation>
+                <translation lang="en_US">Uploading image in progress...</translation>
+                <translation lang="nl_NL">Bezig met uploaden van de afbeelding...</translation>
             </translations>
         </property>
     </properties>

--- a/src/CameraWidgetForPhoneGap/CameraWidgetForPhoneGap.xml
+++ b/src/CameraWidgetForPhoneGap/CameraWidgetForPhoneGap.xml
@@ -10,10 +10,14 @@
             <category>Button</category>
             <description>The CSS class on the button</description>
         </property>
-        <property key="buttonText" type="string" defaultValue="activate camera">
+        <property key="buttonText" type="translatableString">
             <caption>Label</caption>
             <category>Button</category>
             <description/>
+            <translations>
+                <translation lang="en_US">Activate camera</translation>
+                <translation lang="nl_NL">Camera activeren</translation>
+            </translations>
         </property>
         <property key="imageContainerClass" type="string" defaultValue="wx-mxwx-imagecontainer-extra">
             <caption>Image container class</caption>
@@ -51,10 +55,15 @@
             <category>Image quality</category>
             <description>The height of the captured image</description>
         </property>
-        <property key="autoSaveEnabled" type="boolean" defaultValue="false">
-            <caption>Autosave</caption>
+        <property key="autoCapture" type="boolean" defaultValue="false">
+            <caption>Auto capture</caption>
             <category>Behavior</category>
-            <description>Enable autosave to automatically save your image</description>
+            <description>Enable auto capture to automatically start the camera</description>
+        </property>
+        <property key="autoSaveEnabled" type="boolean" defaultValue="false">
+            <caption>Auto save</caption>
+            <category>Behavior</category>
+            <description>Enable auto save to automatically save your image</description>
         </property>
         <property key="onchangemf" type="microflow" required="false">
             <caption>On save microflow</caption>

--- a/src/CameraWidgetForPhoneGap/CameraWidgetForPhoneGap.xml
+++ b/src/CameraWidgetForPhoneGap/CameraWidgetForPhoneGap.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<widget id="CameraWidgetForPhoneGap.widget.CameraWidgetForPhoneGap" needsEntityContext="true" offlineCapable="true"
-        xmlns="http://www.mendix.com/widget/1.0/">
+<widget id="CameraWidgetForPhoneGap.widget.CameraWidgetForPhoneGap" needsEntityContext="true" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/">
     <name>Camera</name>
     <description>Creates a button to use the phone camera option within a Mendix Developer application.</description>
     <icon>iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAA21BMVEUAAAD///+A//9VVVVmZmZVVVVgYGBVVVVmZmZVVVViYmJeXl5SuP9cXFxJtv9YWFhVVVVYWFhXV1dVVVVVVVVXV1dWVlZXV1dJs/lWVlZJs/lVVVVJsfdJsfhIsvhXV1dVVVVWVlZWVlZWVlZVVVVWVlZWVlZVVVVWVlZWVlZVVVVWVlZVVVVVVVVIsfhJsPhJsfhJsfhVVVVJsfdVVVVJsfhVVVVVVVVWVlZJsPdVVVVVVVVVVVVWVlZIsPhVVVVJsfhIsPhVVVVVVVVVVVVJsPhVVVVIsPdVVVUd0v+1AAAAR3RSTlMAAQIDBQYICQoMDRMZGRwgJDQ1NkhJSk9QUFdjZWlqcHJ5g4WZmpufoKOrrLCxtLW2vcLIyNHS1d/j5Ons7vDw8fP19vn8/PqNolUAAAJ4SURBVHgB7VdvX+IwDO6YoIhDBO4QYTL+HJwip4ITVByHotv3/0SX5IdzuWxs/vrW5w1tw/OsTZq0Vcn4hll1htPFcrNZLqa/nKr5NfZeY7wKGFaXjb3M9P3uMojBsrufbe6txyABj60MK/k53/77ddKpV0r5fKlS70xet4PzHyl0ox8QnkfNg+j4QXP0HBD6xi5+8SpAvPQOpe2w90LGq2Iy//ge//E+sOLN1uAd7ffHifwn8tSJSsQJ+fcpQaFI37+z1A5YdzSH2FUYtP6LgtqJwgX5Ic6TfeKrVJBCPyb+NP9CukCBViH2gzlH/1kqAyz05NxUHC2MH/f/6YO/xcMpjwVGs/Vf/qDqgA2dvfkh3s6YaYCz5ZnVxf1nCX6CgoV7ssvyH/O3J/iJCj3M7mh9aGL+4P7PnbseJ3Exz7VzmBeYWY2IwBj6I2zY4qNiOjaOjIBwGYkh1q8mtlzBFwrux5RXn5GsYf2g/P/ry9DxkPoe1QesMNXQ7EBvQi0fEEmP9my9nrUN6nD7BChOODyEXkcKHN36hNsjKdAByjAcnkKvLgQM4pMCzOH6mtnrQJmGAgvoVYRA2w/RBoE/zF4ByiIUwG1UEgIzaN+UyzfwMxNLKOFWCgU20MsLgTW0y0qV4WctBPJA2egL6C8huxMJ0onZw4iQYdTfSNpbmSeTEJBAO0smls5ZBXg684Li+amgdP7NC4pqfJQ0N13AjZY0UVTtdAGbFVVe1llRjYXnnudkWZcHi0TawSKPNgl5tOkfrvrHu/4FQ/+Ko3/J0r/m6V809a+6Wpdtjeu+xoND48mj8egapzy6BMza57Nv6NR2zP0b/wDScUGfAMfR4QAAAABJRU5ErkJggg==</icon>
@@ -77,6 +76,25 @@
                 <enumerationValue key="camera">Camera</enumerationValue>
                 <enumerationValue key="gallery">Gallery</enumerationValue>
             </enumerationValues>
+        </property>
+        <property key="blockingUpload" type="enumeration" defaultValue="disabled">
+            <caption>Block during upload</caption>
+            <category>Behaviour</category>
+            <description>Show progress message during upload (block UI) prevent form user interaction. Or 'On form save' upload can be started, only on save of the form show progress will be shown when the upload is not completed</description>
+            <enumerationValues>
+                <enumerationValue key="disabled">None</enumerationValue>
+                <enumerationValue key="duringUpload">During upload</enumerationValue>
+                <enumerationValue key="onFormSave">On from save</enumerationValue>
+            </enumerationValues>
+        </property>
+        <property key="progressText" type="translatableString" required="false" >
+            <caption>Progress upload text</caption>
+            <category>Behaviour</category>
+            <description/>
+            <translations>
+                <translation lang="en_US">Uploading image in progress ...</translation>
+                <translation lang="nl_NL">Bezig met uploaden van de afbeelding ...</translation>
+            </translations>
         </property>
     </properties>
 </widget>

--- a/src/CameraWidgetForPhoneGap/widget/CameraWidgetForPhoneGap.js
+++ b/src/CameraWidgetForPhoneGap/widget/CameraWidgetForPhoneGap.js
@@ -45,7 +45,9 @@ require([
             }
             this._setPicture("");
 
-            if (callback) callback();
+            if (callback) {
+                callback();
+            }
         },
 
         _updateRendering: function() {
@@ -143,19 +145,8 @@ require([
                 return;
             }
 
-            var sourceType = (this.pictureSource == "camera")
-                ? Camera.PictureSourceType.CAMERA
-                : Camera.PictureSourceType.PHOTOLIBRARY;
-            var params = {
-                quality: 100,
-                destinationType: Camera.DestinationType.FILE_URL,
-                correctOrientation: true,
-                sourceType: sourceType
-            };
-            if (this.targetWidth !== 0) params.targetWidth = this.targetWidth;
-            if (this.targetHeight !== 0) params.targetHeight = this.targetHeight;
-            // TODO: get rid of temp image files
-            navigator.camera.getPicture(success, error, params);
+            var options = this._getOptions();
+            navigator.camera.getPicture(success, error, options);
 
             function success(url) {
                 if (self.autoSaveEnabled) {
@@ -178,6 +169,23 @@ require([
             }
         },
 
+        _getOptions() {
+            var sourceType = this.pictureSource == "camera"
+                ? Camera.PictureSourceType.CAMERA
+                : Camera.PictureSourceType.PHOTOLIBRARY;
+
+            var options = {
+                quality: 100,
+                destinationType: Camera.DestinationType.FILE_URL,
+                correctOrientation: true,
+                sourceType: sourceType,
+                targetWidth: this.targetWidth !== 0 ? this.targetWidth : undefined,
+                targetHeight: this.targetHeight !== 0 ? this.targetHeight : undefined
+            };
+
+            return options;
+        },
+
         _sendFile: function(callback) {
             logger.debug(this.friendlyId + "._sendFile");
             this.uploadError = false;
@@ -185,7 +193,9 @@ require([
 
             if (!this._imageUrl) {
                 self._hideProgress();
-                if (callback) callback();
+                if (callback) {
+                    callback();
+                }
                 return;
             }
             if (this.blockingUpload === "duringUpload") {
@@ -216,7 +226,9 @@ require([
                     self._setPicture("");
                     self._hideProgress();
                     logger.debug(self.id + ".upload done");
-                    if (callback) callback();
+                    if (callback) {
+                        callback();
+                    }
                 });
             }
 
@@ -236,17 +248,17 @@ require([
                 if (this.blockingUpload === "duringUpload") {
                     this._showProgress();
                 }
-                 window.mx.data.commit({
-                     mxobj: this._contextObj,
-                     callback: function(){
+                window.mx.data.commit({
+                    mxobj: this._contextObj,
+                    callback: function(){
                         this._sendFile();
-                     },
-                     error: function(error) {
+                    },
+                    error: function(error) {
                         this.uploadError = true;
+                        this._hideProgress();
                         logger.error(this.friendlyId + " Error committing image ", error);
                         window.mx.ui.error("Error saving image " + error.message);
-                        this._hideProgress();
-                     }
+                    }
                 }, this);
             }
         },

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="CameraWidgetForPhoneGap" version="3.4.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="CameraWidgetForPhoneGap" version="4.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="CameraWidgetForPhoneGap/CameraWidgetForPhoneGap.xml"/>
         </widgetFiles>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="CameraWidgetForPhoneGap" version="3.3.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="CameraWidgetForPhoneGap" version="3.4.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="CameraWidgetForPhoneGap/CameraWidgetForPhoneGap.xml"/>
         </widgetFiles>


### PR DESCRIPTION
Prevent users from editing or closing  the form while the image is uploading:
- This can be done directly with the auto upload or on form save
- The progress message could be shown always 'During upload' (block UI) preventing user from interacting with the for. Or 'On form save' with 'Autosave', the upload can already be started while the form is edited, and only show the progress on saving the form when the upload is not completed yet.