### PR TITLE
JS const causes error in Android

### DIFF
--- a/src/CameraWidgetForPhoneGap/widget/CameraWidgetForPhoneGap.js
+++ b/src/CameraWidgetForPhoneGap/widget/CameraWidgetForPhoneGap.js
@@ -168,8 +168,8 @@ require([
             function error(error) {
                 mx.ui.hideProgress(blockInputHandle);
                 var message = error ? error.trim().toLowerCase() : "unknown";
-                const cameraError = "no image selected."
-                const cameraError2 = "camera cancelled."
+                var cameraError = "no image selected.";
+                var cameraError2 = "camera cancelled.";
                 if (message.indexOf(cameraError) > -1 && message.indexOf(cameraError2) > -1) {
                     window.mx.ui.error("Error while retrieving image with error " + error);
                     logger.error(self.friendlyId + " : error while retrieving image", error);


### PR DESCRIPTION
We had an issue on a Galaxy Tab running Android 4.4.4 with the const statements in the code. In the device widgets.js was not loaded at all because of error SyntaxError: Use of const in strict mode. Changing the const to var (and adding a semicolon) fixed the issue. 